### PR TITLE
Aceitacao de parametros na pesquisa de animes e mangas.

### DIFF
--- a/lib/functions/genre/animesByGenre.ts
+++ b/lib/functions/genre/animesByGenre.ts
@@ -4,22 +4,17 @@ import AnimeByGenre, { Anime } from '../../interfaces/genre/AnimeByGenre';
 
 export default async function animesByGenre(
   id: number,
-  limit?: number,
-  page?: number,
+  params?: { [Key: string]: number }
 ): Promise<AnimeByGenre> {
-  const { data } = await api.get<AnimeByGenre>(
-    `/genre/anime/${id}/${page || ''}`,
-  );
+  let url = `/search/anime?genre=${id}`;
 
-  if (limit) {
-    const items: Anime[] = [];
-
-    for (let i = 0; i < limit; i += 1) {
-      items.push(data.anime[i]);
+  for(let param in params) {
+    if(params[param]) {
+      url += `&${param}=${params[param]}`;
     }
-
-    data.anime = items;
   }
+
+  const { data } = await api.get<AnimeByGenre>(url);
 
   return data;
 }

--- a/lib/functions/genre/mangasByGenre.ts
+++ b/lib/functions/genre/mangasByGenre.ts
@@ -4,22 +4,17 @@ import MangaByGenre, { Manga } from '../../interfaces/genre/MangaByGenre';
 
 export default async function mangasByGenre(
   mal_id: number,
-  limit?: number,
-  page?: number,
+  params?: { [Key: string]: number }
 ): Promise<MangaByGenre> {
-  const { data } = await api.get<MangaByGenre>(
-    `/genre/manga/${mal_id}/${page || ''}`,
-  );
+  let url = `/search/manga?genre=${mal_id}`;
 
-  if (limit) {
-    const items: Manga[] = [];
-
-    for (let i = 0; i < limit; i += 1) {
-      items.push(data.manga[i]);
+  for(let param in params) {
+    if(params[param]) {
+      url += `&${param}=${params[param]}`;
     }
-
-    data.manga = items;
   }
+  
+  const { data } = await api.get<MangaByGenre>(url);
 
   return data;
 }


### PR DESCRIPTION
Achei esse modo melhor e mais legal de pesquisar animes e mangás, o primeiro parâmetro de animeByGenre é o id do gênero e o segundo(opcional) é um objeto que pode ter como chaves: page, type, status, rated, genre, score, start_date, end_date, genre_exclude. Isso também funciona em mangasByGenre.

Exemplo: animeByGenre(8, {score: 9, limit: 5})